### PR TITLE
Update docker-compose.example.yaml

### DIFF
--- a/docker-compose.example.yaml
+++ b/docker-compose.example.yaml
@@ -37,7 +37,7 @@ services:
             APPLICATION_SECRET: letmein
             KM_ARGS: -Djava.net.preferIPv4Stack=true
     snowplow_collector:
-        image: kafkasp:1
+        image: kafkasp:latest
         ports:
             - '8081:8081'
         links:


### PR DESCRIPTION
docker-compose up failed because the tag for kafkasp was set to '1'. Replaced '1' with 'latest', which resolved the issue.
I found the solution by running 'docker images' and examining the kafkasp tag.

Thank you for a great repo!